### PR TITLE
Dialog Box Fix

### DIFF
--- a/api/deleteContactById.php
+++ b/api/deleteContactById.php
@@ -44,7 +44,6 @@ if (!empty($_GET['contactId'])) {
     if ($stmt->execute()) {
         if ($stmt->rowCount() > 0) {
             http_response_code(200);
-            echo json_encode(["message" => "Contact successfully deleted"]);
         } else {
             http_response_code(404);
             echo json_encode(["message" => "No contact found with the provided id"]);

--- a/api/updateContact.php
+++ b/api/updateContact.php
@@ -85,15 +85,12 @@ if (
         if ($stmt->execute()) {
             if ($stmt->rowCount() > 0) {
                 http_response_code(200); 
-                echo json_encode(["message" => "Contact updated successfully."]);
             } else {
                 // No changes were made
                 http_response_code(200); 
-                echo json_encode(["message" => "No changes were made to the contact."]);
             }
         } else {
             http_response_code(500);
-            echo json_encode(["message" => "Failed to update contact."]);
         }
 
 


### PR DESCRIPTION
We should not have pop up dialog boxes for any reason unless it is confirming to delete something. While we do have a popup box for confirming to delete a contact, we do not need a popup box to notify you that it was successfully deleted.